### PR TITLE
refactor: extract section label component

### DIFF
--- a/src/components/structura/blog-section.tsx
+++ b/src/components/structura/blog-section.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import { posts as mockPosts } from "@/lib/data";
 import { Separator } from "@/components/ui/separator";
 import { ArrowUpRight } from "lucide-react";
+import { SectionLabel } from "@/components/ui/section-label";
 
 export default function BlogSection() {
   const posts = mockPosts;
@@ -12,7 +13,7 @@ export default function BlogSection() {
       <div className="container mx-auto px-8">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-12">
           <div className="blog__header lg:col-span-4 lg:sticky top-24 self-start">
-            <p className="text-accent font-semibold mb-2">BLOG</p>
+            <SectionLabel>BLOG</SectionLabel>
             <h2 id="blog-title" className="text-3xl lg:text-4xl font-bold mb-4">
               Latest Blogs
             </h2>

--- a/src/components/structura/resume-section.tsx
+++ b/src/components/structura/resume-section.tsx
@@ -2,6 +2,7 @@ import { resume as mockResume } from "@/lib/data";
 import { Briefcase, GraduationCap, ArrowUpRight } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import Link from "next/link";
+import { SectionLabel } from "@/components/ui/section-label";
 
 interface ResumeItemProps {
   title: string;
@@ -49,7 +50,7 @@ export default function ResumeSection() {
     <section id="resume" className="py-20 lg:py-32" aria-labelledby="resume-title">
       <div className="container mx-auto px-8">
         <div className="mb-12 max-w-2xl">
-             <p className="text-accent font-semibold mb-2">EXPERIENCE</p>
+             <SectionLabel>EXPERIENCE</SectionLabel>
             <h2 id="resume-title" className="text-3xl lg:text-4xl font-bold">
                 My Experience
             </h2>

--- a/src/components/structura/services-section.tsx
+++ b/src/components/structura/services-section.tsx
@@ -1,3 +1,5 @@
+import { SectionLabel } from "@/components/ui/section-label";
+
 export default function ServicesSection() {
   const services = [
     {
@@ -39,7 +41,7 @@ export default function ServicesSection() {
     <section id="services" className="py-20 lg:py-32" aria-labelledby="services-title">
       <div className="container mx-auto px-8">
         <div className="text-center mb-12 max-w-3xl mx-auto">
-            <p className="text-accent font-semibold mb-2">SERVICES</p>
+            <SectionLabel>SERVICES</SectionLabel>
           <h2 id="services-title" className="text-3xl lg:text-4xl font-bold mb-4">
             Design that solves problems, one product at a time.
           </h2>

--- a/src/components/structura/testimonial-section.tsx
+++ b/src/components/structura/testimonial-section.tsx
@@ -9,6 +9,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { SectionLabel } from "@/components/ui/section-label";
 
 export default function TestimonialSection() {
   const testimonials = mockTestimonials;
@@ -17,7 +18,7 @@ export default function TestimonialSection() {
     <section id="testimonial" className="py-20 lg:py-32" aria-labelledby="testimonial-title">
       <div className="container mx-auto px-8">
         <div className="mb-12 max-w-2xl">
-            <p className="text-accent font-semibold mb-2">TESTIMONIALS</p>
+            <SectionLabel>TESTIMONIALS</SectionLabel>
             <h2 id="testimonial-title" className="text-3xl lg:text-4xl font-bold">
                 Word on the street
             </h2>

--- a/src/components/ui/section-label.tsx
+++ b/src/components/ui/section-label.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+interface SectionLabelProps {
+  children: React.ReactNode;
+}
+
+function SectionLabel({ children }: SectionLabelProps) {
+  return <p className="text-accent font-semibold mb-2">{children}</p>;
+}
+
+export { SectionLabel };


### PR DESCRIPTION
## Summary
- add reusable SectionLabel component
- replace hardcoded section labels with SectionLabel in services, testimonials, blog, and resume sections

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires ESLint configuration)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b956459200832fba23023c9142d338