### PR TITLE
feat: consolidate gradient headline style

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,3 +99,10 @@
       box-shadow: 0 10px 20px rgba(0,0,0,0.1);
   }
 }
+
+@layer utilities {
+  .gradient-headline {
+    @apply text-transparent bg-clip-text;
+    background: linear-gradient(90deg, #ff7a18, #af002d 70%, #319197);
+  }
+}

--- a/src/components/structura/about-section.tsx
+++ b/src/components/structura/about-section.tsx
@@ -6,11 +6,7 @@ export default function AboutSection() {
       <div className="container mx-auto px-8">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start mb-16">
           <div className="about__content-left">
-            <p className="font-semibold text-sm uppercase tracking-[1.5px] mb-4" style={{
-                background: 'linear-gradient(90deg, #ff7a18, #af002d 70%, #319197)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent'
-            }}>
+            <p className="font-semibold text-sm uppercase tracking-[1.5px] mb-4 gradient-headline">
               Business Technology Consultant
             </p>
             <h2 id="about-me-title" className="text-4xl md:text-5xl font-bold" style={{lineHeight: 1.2}}>

--- a/src/components/structura/faq-section.tsx
+++ b/src/components/structura/faq-section.tsx
@@ -39,11 +39,7 @@ export default function FaqSection() {
     <section id="faq" className="py-20 lg:py-32 bg-[#111111] text-white" aria-labelledby="faq-title">
       <div className="container mx-auto px-8 max-w-6xl">
         <div className="mb-16 text-center">
-            <p className="font-semibold text-sm uppercase tracking-[1.5px] mb-4" style={{
-                background: 'linear-gradient(90deg, #ff7a18, #af002d 70%, #319197)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent'
-            }}>
+            <p className="font-semibold text-sm uppercase tracking-[1.5px] mb-4 gradient-headline">
               FAQ
             </p>
           <h2 id="faq-title" className="text-4xl lg:text-5xl font-bold">


### PR DESCRIPTION
## Summary
- add `.gradient-headline` utility for shared text gradient
- use `.gradient-headline` in about and FAQ sections

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9565d8920832fbf3d56afd7744361