### PR TITLE
feat: add reusable portfolio image class

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -98,4 +98,8 @@
       transform: translateY(-8px);
       box-shadow: 0 10px 20px rgba(0,0,0,0.1);
   }
+
+  .portfolio-image {
+    @apply w-full h-full object-cover rounded-lg shadow-lg;
+  }
 }

--- a/src/components/structura/about-section.tsx
+++ b/src/components/structura/about-section.tsx
@@ -31,7 +31,7 @@ export default function AboutSection() {
                     alt="A tall phone screen showing a wallet app"
                     width={300}
                     height={620}
-                    className="w-full h-full object-cover rounded-lg shadow-lg"
+                    className="portfolio-image"
                     data-ai-hint="building automations"
                 />
             </div>
@@ -41,7 +41,7 @@ export default function AboutSection() {
                     alt="A designer working at a dual monitor setup"
                     width={600}
                     height={620}
-                    className="w-full h-full object-cover rounded-lg shadow-lg"
+                    className="portfolio-image"
                     data-ai-hint="workspace setup"
                 />
             </div>
@@ -51,7 +51,7 @@ export default function AboutSection() {
                     alt="A workspace with a laptop"
                     width={300}
                     height={310}
-                    className="w-full h-full object-cover rounded-lg shadow-lg"
+                    className="portfolio-image"
                     data-ai-hint="training session"
                 />
                  <Image
@@ -59,7 +59,7 @@ export default function AboutSection() {
                     alt="Two people collaborating over a laptop"
                     width={300}
                     height={310}
-                    className="w-full h-full object-cover rounded-lg shadow-lg"
+                    className="portfolio-image"
                     data-ai-hint="team collaboration"
                 />
             </div>


### PR DESCRIPTION
## Summary
- add `portfolio-image` utility class for consistent image styling
- refactor about section images to use the new class

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9564f289c832f8bccc4e791d5bdfe