### PR TITLE
feat: load portfolio data from Firestore

### DIFF
--- a/src/components/structura/blog-section.tsx
+++ b/src/components/structura/blog-section.tsx
@@ -1,11 +1,18 @@
+"use client";
 import Link from "next/link";
 import { format } from "date-fns";
-import { posts as mockPosts } from "@/lib/data";
+import { useEffect, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 import { ArrowUpRight } from "lucide-react";
+import { getPosts } from "@/lib/data";
+import type { Post } from "@/lib/types";
 
 export default function BlogSection() {
-  const posts = mockPosts;
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    getPosts().then(setPosts).catch(console.error);
+  }, []);
 
   return (
     <section id="blog" className="py-20 lg:py-32 bg-[#111111] text-white" aria-labelledby="blog-title">

--- a/src/components/structura/faq-section.tsx
+++ b/src/components/structura/faq-section.tsx
@@ -1,21 +1,26 @@
 "use client";
 
-import { faqs as mockFaqs } from "@/lib/data";
+import { useEffect, useState } from "react";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { ChevronDown } from "lucide-react";
+import { getFaqs } from "@/lib/data";
+import type { FAQ } from "@/lib/types";
 
 export default function FaqSection() {
-  const faqs = mockFaqs;
+  const [faqs, setFaqs] = useState<FAQ[]>([]);
   const midIndex = Math.ceil(faqs.length / 2);
   const firstHalf = faqs.slice(0, midIndex);
   const secondHalf = faqs.slice(midIndex);
 
-  const FaqColumn = ({ items }: { items: typeof mockFaqs }) => (
+  useEffect(() => {
+    getFaqs().then(setFaqs).catch(console.error);
+  }, []);
+
+  const FaqColumn = ({ items }: { items: FAQ[] }) => (
     <Accordion type="single" collapsible className="w-full flex flex-col">
       {items.map((faq) => (
         <AccordionItem 

--- a/src/components/structura/projects-section.tsx
+++ b/src/components/structura/projects-section.tsx
@@ -1,8 +1,10 @@
 "use client"
 import Link from "next/link";
-import { projects as mockProjects } from "@/lib/data";
+import { useEffect, useState } from "react";
 import ProjectCard from "./project-card";
 import { Button } from "../ui/button";
+import { getProjects } from "@/lib/data";
+import type { Project } from "@/lib/types";
 import {
   Carousel,
   CarouselContent,
@@ -13,7 +15,11 @@ import {
 import Autoplay from "embla-carousel-autoplay";
 
 export default function ProjectsSection() {
-  const projects = mockProjects;
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    getProjects().then(setProjects).catch(console.error);
+  }, []);
 
   return (
     <section id="projects" className="py-20 lg:py-32 bg-background relative z-10" aria-labelledby="projects-title">

--- a/src/components/structura/resume-section.tsx
+++ b/src/components/structura/resume-section.tsx
@@ -1,7 +1,10 @@
-import { resume as mockResume } from "@/lib/data";
+"use client";
+import { useEffect, useState } from "react";
 import { Briefcase, GraduationCap, ArrowUpRight } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import Link from "next/link";
+import { getResume } from "@/lib/data";
+import type { Resume } from "@/lib/types";
 
 interface ResumeItemProps {
   title: string;
@@ -33,7 +36,12 @@ function ResumeItem({ title, subtitle, years, icon }: ResumeItemProps) {
 }
 
 export default function ResumeSection() {
-  const { education, work } = mockResume;
+  const [resume, setResume] = useState<Resume>({ education: [], work: [] });
+  const { education, work } = resume;
+
+  useEffect(() => {
+    getResume().then(setResume).catch(console.error);
+  }, []);
 
   const educationIcons = [
       <GraduationCap key="e1" className="w-6 h-6 text-primary" />,

--- a/src/components/structura/testimonial-section.tsx
+++ b/src/components/structura/testimonial-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { testimonials as mockTestimonials } from "@/lib/data";
+import { useEffect, useState } from "react";
 import {
   Carousel,
   CarouselContent,
@@ -9,9 +9,15 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { getTestimonials } from "@/lib/data";
+import type { Testimonial } from "@/lib/types";
 
 export default function TestimonialSection() {
-  const testimonials = mockTestimonials;
+  const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
+
+  useEffect(() => {
+    getTestimonials().then(setTestimonials).catch(console.error);
+  }, []);
 
   return (
     <section id="testimonial" className="py-20 lg:py-32" aria-labelledby="testimonial-title">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,43 +1,48 @@
-// TODO: This is mock data. Replace with data from a CMS or Firestore.
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "./firebase";
+import type {
+  Project,
+  Post,
+  Testimonial,
+  FAQ,
+  Resume,
+  EducationEntry,
+  WorkEntry,
+} from "./types";
 
-export const projects = [
-  { id: "p1", title: "Sales Inbox Triage Copilot", tag: "AI Copilot", description: "n8n + OpenAI · routes emails, drafts replies, updates CRM", image: "https://placehold.co/600x450.png", url: "#", aiHint: "abstract design" },
-  { id: "p2", title: "HR Assistant for New Hires", tag: "Onboarding", description: "AppSheet/Power Apps · collects docs, answers policy FAQs", image: "https://placehold.co/600x450.png", url: "#", aiHint: "modern website" },
-  { id: "p3", title: "Order Status Tracker", tag: "Logistics", description: "Sheets/ERP + n8n · status updates + WhatsApp notifications", image: "https://placehold.co/600x450.png", url: "#", aiHint: "mobile application" },
-  { id: "p4", title: "Corporate Identity for Startup", tag: "Branding", description: "A fresh new look for a startup.", image: "https://placehold.co/600x450.png", url: "#", aiHint: "corporate branding" },
-  { id: "p5", title: "Interactive Data Visualization", tag: "Web App", description: "Visualizing complex data in an interactive way.", image: "https://placehold.co/600x450.png", url: "#", aiHint: "data visualization" },
-  { id: "p6", title: "Futuristic UI Kit", tag: "UI Design", description: "A UI kit for the future.", image: "https://placehold.co/600x450.png", url: "#", aiHint: "futuristic ui" },
-];
+export async function getProjects(): Promise<Project[]> {
+  const snapshot = await getDocs(collection(db, "projects"));
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as Project));
+}
 
-export const posts = [
-  { id: "b1", title: "Your First 3 Automations for SMEs (No Developers Needed)", dateISO: "2023-04-16T00:00:00.000Z", readMins: 5, url: "#" },
-  { id: "b2", title: "Prompt Systems Teams Actually Use (Templates Inside)", dateISO: "2023-03-22T00:00:00.000Z", readMins: 7, url: "#" },
-  { id: "b3", title: "Connecting Microsoft 365 & Google Workspace the Practical Way", dateISO: "2023-02-10T00:00:00.000Z", readMins: 9, url: "#" },
-  { id: "b4", title: "MVP in 7 Days: A Low-Risk Pilot Playbook", dateISO: "2023-01-15T00:00:00.000Z", readMins: 4, url: "#" },
-  { id: "b5", title: "Compliance-Light Automation: GDPR Basics that Matter", dateISO: "2023-01-01T00:00:00.000Z", readMins: 6, url: "#" },
-];
+export async function getPosts(): Promise<Post[]> {
+  const snapshot = await getDocs(collection(db, "posts"));
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as Post));
+}
 
-export const testimonials = [
-  { id: "t1", authorName: "Jane Doe", authorRole: "Founder, Beta Inc.", avatar: "https://placehold.co/400x400.png", quote: "Clear explanations, fast delivery, and solutions our non-technical team can actually use. Federico didn’t just build a tool, he built our confidence.", aiHint: "woman portrait" },
-  { id: "t2", authorName: "John Smith", authorRole: "CEO, Innovate LLC", avatar: "https://placehold.co/400x400.png", quote: "The final product exceeded all our expectations. The design is not only beautiful but also incredibly intuitive for our users. Highly recommended!", aiHint: "man portrait" },
-  { id: "t3", authorName: "Emily White", authorRole: "Marketing Director, ScaleUp", avatar: "https://placehold.co/400x400.png", quote: "A true professional. They delivered on time, communicated clearly, and produced outstanding work. We've seen a significant increase in engagement since the redesign.", aiHint: "person smiling" },
-];
+export async function getTestimonials(): Promise<Testimonial[]> {
+  const snapshot = await getDocs(collection(db, "testimonials"));
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as Testimonial));
+}
 
-export const faqs = [
-  { id: "f1", question: "What is your hourly rate?", answer: "My hourly rate varies depending on the scope and complexity of the project. For a precise quote, please book a call to discuss your specific needs." },
-  { id: "f2", question: "What services do you offer?", answer: "I offer a range of design services including UI/UX design for web and mobile apps, branding and identity design, and web design. Check the 'Services' section for more details." },
-  { id: "f3", question: "How long will it take to complete my project?", answer: "Project timelines vary based on the project's scope. After our initial consultation, I will provide a detailed project plan with key milestones and a final delivery date." },
-  { id: "f4", question: "What is your design process?", answer: "My process is collaborative and iterative. It typically involves discovery and research, wireframing and prototyping, visual design, and user testing to ensure the final product meets your goals." },
-  { id: "f5", question: "Do you provide a warranty for the final product?", answer: "Absolutely. I offer a 30-day warranty period after project completion to address any bugs or issues that may arise. Your satisfaction is my priority." },
-  { id: "f6", question: "How can I get started?", answer: "The first step is to book a free consultation call with me. We'll discuss your project, goals, and how I can help. From there, I'll prepare a detailed proposal for your review." },
-];
+export async function getFaqs(): Promise<FAQ[]> {
+  const snapshot = await getDocs(collection(db, "faqs"));
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as FAQ));
+}
 
-export const resume = {
-  education: [
-    { id: 'e1', institution: 'Self-directed specialization — AI, Automation & Low-Code (Power Platform, AppSheet, n8n, Prompt Engineering). Ongoing labs and prototypes.', degree: '', years: '' },
-  ],
-  work: [
-    { id: 'w1', company: 'Business Technology Consultant (Freelance)', role: 'AI workflows, copilots, low-code integrations for SMEs.', years: '2025-Present' },
-    { id: 'w2', company: 'Colruyt Group — Operations (2 yrs) · McDonald’s — Crew/Training (2 yrs).', role: 'Process discipline and team enablement informing my consulting style.', years: '' },
-  ]
-};
+export async function getResume(): Promise<Resume> {
+  const educationSnapshot = await getDocs(collection(db, "education"));
+  const workSnapshot = await getDocs(collection(db, "workExperience"));
+
+  const education: EducationEntry[] = educationSnapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  })) as EducationEntry[];
+
+  const work: WorkEntry[] = workSnapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  })) as WorkEntry[];
+
+  return { education, work };
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,14 @@
+import { getApp, getApps, initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+export const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,51 @@
+export interface Project {
+  id: string;
+  title: string;
+  tag: string;
+  description: string;
+  image: string;
+  url: string;
+  aiHint: string;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+  dateISO: string;
+  readMins: number;
+  url: string;
+}
+
+export interface Testimonial {
+  id: string;
+  authorName: string;
+  authorRole: string;
+  avatar: string;
+  quote: string;
+  aiHint: string;
+}
+
+export interface FAQ {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+export interface EducationEntry {
+  id: string;
+  institution: string;
+  degree: string;
+  years: string;
+}
+
+export interface WorkEntry {
+  id: string;
+  company: string;
+  role: string;
+  years: string;
+}
+
+export interface Resume {
+  education: EducationEntry[];
+  work: WorkEntry[];
+}


### PR DESCRIPTION
## Summary
- add project, blog, testimonial, FAQ, and resume types
- load data from Firestore instead of mock arrays
- fetch live data in portfolio sections

## Testing
- `npm run lint` *(fails: project requires eslint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b98510d028832fa6ec3cf5f4f35771